### PR TITLE
Template references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 lib/
 node_modules/
+docs/

--- a/src/types.ts
+++ b/src/types.ts
@@ -58,6 +58,7 @@ export type GenerateOptions = {
 export type TemplateExpressionOptions = {
   preword?: string
   stops?: string[]
+  id?: string
 } & CommonOptions
 
 export type TemplateExpression = {


### PR DESCRIPTION
Expressions can now reference the results of previous expressions - add an `{ id: string}` to the expression option, and in the consuming expression provide a function which takes ref getter
```ts
template`{
  "name": "${a('name', {id: 'name'})}",
  "description": "${ref => a('good description for ' + ref('name'))}"
}`})
```