### PR TITLE
Rework context API

### DIFF
--- a/example/vite-demo/hn/main.ts
+++ b/example/vite-demo/hn/main.ts
@@ -27,7 +27,7 @@ const hnApiGetRandomWhosHiring = async (tries = 2): Promise<string> => {
 }
 
 renderTemplate(app, async () => {
-  const createCtx = ad(
+  const { context, a, prompt } = ad(
     await loadModel(
       'Llama-2-7b-chat-hf-q4f32_1',
       report => app.innerHTML = `<pre id='progress'><code>${JSON.stringify(report, null, 2)}</code></pre>`,
@@ -39,7 +39,7 @@ renderTemplate(app, async () => {
 
   const listing = await hnApiGetRandomWhosHiring()
 
-  const { template, a, __ } = createCtx(
+  const assistant = context(
     'You are a helpful assistant that catalogues job listings. Fill the next field in the following JSON object. For any requests for which there is not sufficient information based on the listing itself, fill the field with the string "NA".',
     `\nThe listing:\n"""\n${listing}\n"""\n`,
     {
@@ -57,7 +57,7 @@ renderTemplate(app, async () => {
     stops: [' ', '\n']
   }
 
-  return template`{
+  return assistant`{
   "company": {
     "name": "${a('name for the company')}",
     "description": "${a('description for the company')}",
@@ -82,13 +82,13 @@ renderTemplate(app, async () => {
   },
   "skills": ["${a('list of skills')}],
   "remote": {
-    "allowed": ${__('true if remote is allowed for this listing, else false. If the listing says ONSITE, that means remote is not allowed.', {
+    "allowed": ${prompt('true if remote is allowed for this listing, else false. If the listing says ONSITE, that means remote is not allowed.', {
       stops: ['}',' ','\n'],
       validate: {
         check: validate.json.bool,
         retries: 2
       }
     })},
-    "info": "${__('Any additional information about remote work at the company.')}"
+    "info": "${prompt('Any additional information about remote work at the company.')}"
   }
 }`})

--- a/example/vite-demo/main.ts
+++ b/example/vite-demo/main.ts
@@ -18,9 +18,9 @@ renderTemplate(app, async () => {
         : TargetDevice.CPU 
     )
 
-  const createCtx = ad(model)
+  const { context, a } = ad(model)
 
-  const { template, a } = createCtx(
+  const dm = context(
     'You are a dungeon master.',
     'Create an interesting character based on the Dungeons and Dragons universe.'
   )
@@ -28,7 +28,7 @@ renderTemplate(app, async () => {
   const { bias } = model
   const { oneOf, consistsOf, chars } = sample
 
-  return template`{
+  return dm`{
   "class": "${a('primary class for the character', {
     sampler: bias.reject(oneOf(['Ranger', 'Rogue'].flatMap(alsoToLowerCase)))
   })}",

--- a/example/vite-demo/murder/main.ts
+++ b/example/vite-demo/murder/main.ts
@@ -40,6 +40,8 @@ const showAndWaitUserInput = (): Promise<string> => new Promise(resolve => {
   const form = el('form') as HTMLFormElement
   const submit = el('button', x => { x.type = 'submit'; x.innerText = '>'})
 
+  form.className = 'action'
+
   form.onsubmit = (ev: any) => {
     ev.preventDefault()
     const value = ev.target[0].value

--- a/example/vite-demo/murder/style.css
+++ b/example/vite-demo/murder/style.css
@@ -12,7 +12,26 @@ li p.secret {
   font-style: italic;
 }
 
-input {
+p {
+  white-space: pre-wrap;
+}
+
+form.action {
+  background: burlywood;
+  padding: 0.25rem .5rem;
+  display: flex;
+  align-items: center;
+  border-radius: 8px;
+}
+
+form.action input {
   margin: .5rem 1rem;
   padding: 0.45rem;
+  flex: 1 0;
+}
+
+@media (prefers-color-scheme: light) {
+  form.action {
+    background: cornsilk;
+  }
 }

--- a/example/vite-demo/playground/main.ts
+++ b/example/vite-demo/playground/main.ts
@@ -36,10 +36,8 @@ const view = new EditorView({
 })
 
 const editorContainer = document.querySelector('div.cm-editor') as HTMLDivElement
-console.log({editorContainer})
 
 const onresize = new ResizeObserver( () => {
-  console.log('resize')
   view.requestMeasure()
 })
 

--- a/example/vite-demo/playground/main.ts
+++ b/example/vite-demo/playground/main.ts
@@ -57,7 +57,7 @@ const run = async (code: string) => {
   await model.cancel()
 
   // @ts-expect-error: unused here but available in eval
-  const createCtx = ad(model)
+  const { context, a, prompt } = ad(model)
 
   renderTemplate(inference, async () => {
     try {

--- a/example/vite-demo/playground/placeholder.ts
+++ b/example/vite-demo/playground/placeholder.ts
@@ -1,12 +1,12 @@
-export default `const { template, a, __ } = createCtx(
+export default `const { bias } = model
+const { oneOf, consistsOf, chars } = sample
+
+const { template, a, __ } = createCtx(
   'You are a dungeon master.',
   'Create an interesting non-player character based on the Dungeons and Dragons universe.'
 )
 
 const classes = [ 'Barbarian', 'Bard', 'Cleric', 'Druid', 'Fighter', 'Monk', 'Paladin', 'Ranger', 'Rogue', 'Sorcerer', 'Warlock', 'Wizard' ]
-
-const { bias } = model
-const { oneOf, consistsOf, chars } = sample
 
 template\`{
   "class": "\${a('main class', { sampler: bias.accept(oneOf(classes)) })}",

--- a/example/vite-demo/playground/placeholder.ts
+++ b/example/vite-demo/playground/placeholder.ts
@@ -1,14 +1,14 @@
 export default `const { bias } = model
 const { oneOf, consistsOf, chars } = sample
 
-const { template, a, __ } = createCtx(
+const dnd = context(
   'You are a dungeon master.',
   'Create an interesting non-player character based on the Dungeons and Dragons universe.'
 )
 
 const classes = [ 'Barbarian', 'Bard', 'Cleric', 'Druid', 'Fighter', 'Monk', 'Paladin', 'Ranger', 'Rogue', 'Sorcerer', 'Warlock', 'Wizard' ]
 
-template\`{
+dnd\`{
   "class": "\${a('main class', { sampler: bias.accept(oneOf(classes)) })}",
   "subclass": "\${a('sub class')}",
   "name": "\${(a('name'))}",

--- a/readme.md
+++ b/readme.md
@@ -14,24 +14,33 @@ say hi in [discord](https://discord.gg/Jag2h3fS4C)!
 `npm install -S ad-llama`
 
 ```javascript
-import { loadModel, ad } from 'ad-llama'
+import { loadModel, ad, report } from 'ad-llama'
 
-const loadedModel = await loadModel('Llama-2-7b-chat-hf-q4f32_1')
-const createContext = ad(loadedModel)
+const loadedModel = await loadModel('Llama-2-7b-chat-hf-q4f32_1', report(console.info))
+const { context, a } = ad(loadedModel)
 
-const { template, a } = createContext(
+const dm = context(
   'You are a dungeon master.',
   'Create an NPC based on the Dungeons and Dragons universe.'
 )
 
-const npc = template`{
+const npc = dm`{
   "description": "${a('short description')}",
   "name": "${a('character name')}",
   "weapon": "${a('weapon')}",
   "class": "${a('primary class')}"
 }`
 
-console.log(await npc.collect())
+const generatedNpc = await npc.collect(partial => {
+  switch (partial.type) {
+    case 'gen':
+    case 'lit':
+      console.info(partial.content)
+      break
+  }
+})
+
+console.log(generatedNpc)
 ```
 
 For an example of more complicated usage including validation, retry logic and transforms check the hackernews [who's hiring example.](https://github.com/gsuuon/ad-llama/tree/main/example/vite-demo/hn/main.ts)

--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ For an example of more complicated usage including validation, retry logic and t
 ## Generation
 Each expression in the template literal is a new prompt and options. The prompt given for each expression is added to the system and preprompt established in context, and prior completion text (literal parts and as well as inferences) are added to the end of the LLM prompt as a partially completed assistant response (i.e. after [/INST]).
 
-Each template expression can be configured independently - you can set a different temperature, token count, max length and more. Check the `TemplateExpressionOptions` type in [./src/types.ts](https://github.com/gsuuon/ad-llama/tree/main/src/types.ts) for all options. `a` adds the preword to the expression prompt (by default "Generate a"), you can use `__` to provide a naked prompt, or configure the preword as needed. A plain string gets inserted as literal text, just like normal template literals.
+Each template expression can be configured independently - you can set a different temperature, token count, max length and more. Check the `TemplateExpressionOptions` type in [./src/types.ts](https://github.com/gsuuon/ad-llama/tree/main/src/types.ts) for all options. `a` adds the preword to the expression prompt (by default "Generate"), use `prompt` to provide a naked prompt or set the `preword` option. A plain string gets inserted as literal text, just like normal template literals.
 
 ```typescript
 template`{
@@ -72,7 +72,10 @@ const model = await loadModel(...)
 const { bias } = model
 const { oneOf, consistsOf } = sample
 
-template`{
+const { context, a } = ad(model)
+const character = context('Create a character')
+
+character`{
   "weapon": "${a('special weapon', {
     sampler: bias.prefer(oneOf(['Nun-chucks', 'Beam Cannon']), 10),
   })}",

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,34 @@ export const loadModel = async (
   }
 }
 
+const keys = <T extends Object>(o: T) => Object.keys(o) as (keyof T)[]
+
+export const report = (log: (text: string) => void) => {
+  let lastReport: LoadReport | undefined;
+
+  const _log = (label: string, value: any) => {
+    const valueStr = value instanceof Object ? '\n' + JSON.stringify(value, null, 2) : value
+
+    log(`${label}: ${valueStr}`)
+  }
+
+  return (report: LoadReport) => {
+    if (lastReport !== undefined) {
+      for (const label of keys(lastReport)) {
+        if (lastReport[label] !== report[label]) {
+          _log(label, report[label])
+        }
+      }
+    } else {
+      for (const label of keys(report)) {
+        _log(label, report[label])
+      }
+    }
+
+    lastReport = report
+  }
+}
+
 /// <reference types="vite/client" />
 if (import.meta.hot) {
   import.meta.hot.accept()
@@ -313,7 +341,7 @@ export const ad = (model: LoadedModel): CreateTemplate => {
   }
 }
 
-export { TargetDevice, StreamPartial, LoadedModel } from './types.js'
+export { TargetDevice, StreamPartial, LoadedModel, GenerationStreamHandler } from './types.js'
 
 export * as validate from './validate.js'
 export * as sample from './sample.js'

--- a/src/index.ts
+++ b/src/index.ts
@@ -234,7 +234,8 @@ type WithRef<T> = (ref: (id: string) => string | undefined) => T
  * @example
  * ```
  * import { ad, loadModel } from 'ad-llama'
- * const createContext = ad(await loadModel('Llama-2-7b-chat-hf-q4f32_1'))
+ *
+ * const { context, a, prompt } = ad(await loadModel('Llama-2-7b-chat-hf-q4f32_1'))
  * ```
  */
 export const ad = (model: LoadedModel): CreateTemplate => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -191,7 +191,7 @@ type CreateTemplateContext =
  */
 type CreateTemplate = {
   /** Set a common system prompt and preprompt, as well as common configuration ({@link TemplateExpressionOptions}) for child templates. */
-  context: (system: string, preprompt?: string, config?: TemplateExpressionOptions) => CreateTemplateContext
+  context: (system: string, preprompt?: string, config?: TemplateContextOptions) => CreateTemplateContext
   /** A template expression with the preword prepended to the prompt - defaults to 'Generate' */
   a: (prompt: string, options?: TemplateExpressionOptions) => TemplateExpression
   /** A template expression with an unaltered prompt */

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -18,7 +18,7 @@ import type {
 enum ModelState {
   Waiting,
   Running,
-  Cancelling,
+  Cancelling
 }
 
 const scope = (name?: string) => 'ad-llama' + name ? '/' + name : ''
@@ -506,7 +506,15 @@ export default async (
   updateReport({ ready: true })
 
   return {
-    generate,
+    generate: async (prompt, priorCompletion, stops, options?) => {
+      try {
+        return await generate(prompt, priorCompletion, stops, options)
+      } catch (e) {
+        unfill()
+        modelState = ModelState.Waiting
+        throw e
+      }
+    },
     bias,
     setContext: async (system: string, preprompt?: string) => {
       system_ = `<<sys>>${system}<</sys>>\n\n`

--- a/src/loadModel.ts
+++ b/src/loadModel.ts
@@ -436,10 +436,6 @@ export default async (
           break
         }
       }
-
-      console.info('generate', {
-        acceptedCount: accepted.tokens.length
-      })
     }
 
     // TODO eos token
@@ -497,6 +493,11 @@ export default async (
     }
 
     perf.summarize()
+
+    console.info('generate', prompt, {
+      acceptedCount: accepted.tokens.length,
+      completion: accepted.completion
+    })
 
     return accepted.completion
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -56,13 +56,18 @@ export type GenerateOptions = {
 } & CommonOptions
 
 export type TemplateExpressionOptions = {
-  preword?: string
   stops?: string[]
   id?: string
 } & CommonOptions
 
+export type TemplateContextOptions =
+  Omit<TemplateExpressionOptions, 'id'> & {
+  preword?: string
+}
+
 export type TemplateExpression = {
   prompt: string
+  preword?: string
   options?: TemplateExpressionOptions
 } | string
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -76,7 +76,7 @@ export type TemplateExpression = {
  *
  * @example
  * ```
- * const createContext = ad(loadedModel)
+ * const { context, a, prompt } = ad(loadedModel)
  * ```
  */
 export type LoadedModel = {


### PR DESCRIPTION
Breaking changes - move the `a` and `__` template helpers to the `ad(model)` level, rename `__` to `prompt`, and replace `createContext` with `const { context, a , prompt }`.

This cleans up the API a bit and allows using the variable name to retain the context of a template creator, eg
```ts
const dnd = context('You are a DnD dungeon master')

dnd`{
  ...
}`
```

It also removes ambiguity and using the wrong `a` when running multiple contexts. `a` now always defaults to the preword of the context it's used in.